### PR TITLE
Add util/parseMapString.

### DIFF
--- a/lib/util/parseMapString.js
+++ b/lib/util/parseMapString.js
@@ -1,0 +1,22 @@
+﻿"use strict";
+
+module.exports = function parseBindingMap(bindingMap, bindingTarget) {
+    var pieces = bindingMap.split(",").filter(function (piece) { return !!piece; });
+    
+    var map = Object.create(null);
+
+    pieces.forEach(function (piece) {
+        var parts = piece.split(":");
+        var key = parts[0].trim().toLowerCase();
+        var value = parts[1].trim();
+
+        if (!(value in bindingTarget)) {
+            throw new TypeError("The binding target has no property \"" + value + "\".");
+        }
+        var bindTo = bindingTarget[value];
+
+        map[key] = bindTo;
+    });
+
+    return map;
+};

--- a/test/util_parseMapString.coffee
+++ b/test/util_parseMapString.coffee
@@ -1,0 +1,17 @@
+"use strict"
+
+parseMapString = require("../lib/util/parseMapString")
+
+describe "Parsing a map string", ->
+    bound = { a: {}, b: {}, c: {}, d: {} }
+
+    it "click: a", ->
+        expect(parseMapString("click: a", bound)).to.have.property("click", bound.a)
+
+    it "click: a, itemInvoked: b", ->
+        result = parseMapString("click: a, itemInvoked: b", bound)
+        expect(result).to.have.property("click", bound.a)
+        expect(result).to.have.property("iteminvoked", bound.b)
+
+    it "click: a, itemInvoked: nobody", ->
+        expect(-> parseMapString("click: a, itemInvoked: nobody", bound)).to.throw(TypeError, "nobody")


### PR DESCRIPTION
Parses (very simplistically) map strings in the form `"x: y, z: w"`, returning a map from the keys to those properties of a target object given by the values. It will lowercase the keys for you.

No real error handling or input validation, for now. Easy to add later.
