### PR TITLE
Add querystring support to the Navigator

### DIFF
--- a/lib/ui/Navigator.js
+++ b/lib/ui/Navigator.js
@@ -24,11 +24,12 @@ module.exports = function Navigator(nav, pageParentEl) {
         $newPage.show();
     });
 
-    that.navigate = function (location) {
+    that.navigate = function (location, state) {
         if (!location) {
             throw new Error("location parameter is required.");
         }
-        nav.navigate(location);
+
+        nav.navigate(location, state);
     };
 
     that.listenToClicks = function (element) {

--- a/lib/ui/Navigator.js
+++ b/lib/ui/Navigator.js
@@ -1,10 +1,7 @@
 ﻿"use strict";
 
 var $ = require("jquery-browserify");
-
-function getPageId(url) {
-    return url.substring(url.lastIndexOf("/") + 1);
-}
+var parseUrl = require("url").parse;
 
 module.exports = function Navigator(nav, pageParentEl) {
     var that = this;
@@ -12,7 +9,7 @@ module.exports = function Navigator(nav, pageParentEl) {
     nav.addEventListener("navigated", function (e) {
         $(pageParentEl).children("section[data-winning-page]").hide();
 
-        var newPageName = getPageId(e.detail.location);
+        var newPageName = e.detail.location;
         var $newPage = $(pageParentEl).children("section[data-winning-page='" + newPageName + "']");
         if ($newPage.length === 0) {
             throw new Error('Could not find page "' + newPageName + '".');
@@ -35,12 +32,20 @@ module.exports = function Navigator(nav, pageParentEl) {
     that.listenToClicks = function (element) {
         $(element).on("click", "a, button", function (ev) {
             var href = this.getAttribute("href") || this.getAttribute("data-winning-href");
-            if (href) {
-                ev.preventDefault();
-
-                var location = getPageId(href);
-                that.navigate(location);
+            if (!href) {
+                return;
             }
+
+            var url = parseUrl(href, true);
+            if (url.protocol) {
+                return;
+            }
+
+            var pageName = url.pathname.substring(1); // remove leading "/".
+            var state = url.query;
+
+            ev.preventDefault();
+            that.navigate(pageName, state);
         });
     };
 };

--- a/test/ui_Navigator.coffee
+++ b/test/ui_Navigator.coffee
@@ -48,9 +48,9 @@ describe "Navigator", ->
         it "should throw no location found", ->
             (-> @navigator.navigate()).should.throw()
 
-        it "should call 'nav' navigate method", ->
-            @navigator.navigate("about")
-            @nav.navigate.should.have.been.calledWith("about")
+        it "should call 'nav' navigate method with the passed location and state", ->
+            @navigator.navigate("about", { foo: "bar" })
+            @nav.navigate.should.have.been.calledWith("about", { foo: "bar" })
 
         it "should show and hide sections", ->
             @navigator.navigate("about")


### PR DESCRIPTION
This pull request is currently incomplete and needs discussion to complete. But here's the foundation.

As of these two commits, you can now pass a `state` object to `navigator.navigate`; furthermore, putting querystrings into your `href` or `data-winning-href` attributes will parse them and then pass them along to that same method.

HOWEVER, that method currently does nothing with its `state` parameter! We need to decide how to communicate the passed state to the page being shown.

It's important to remember that pages are just components that happen to have `data-winning-page` attributes. So we can leverage the component infrastructure. But, we don't (inside the navigation handler) have access to the component directly---just to its root DOM element.

Here's an idea:
- Trigger a custom DOM event, say `"show"`, on the root DOM element for the newly-shown page. It gets the state as its event object. So it'd be `$newPage.trigger("show", state)`.
- Use `data-bind` to hook this up to the view model for a given component. So it would be `data-bind="{ events: { 'show': processState }"`. Then the component's view model has a `processState` method that reconfigures itself.

This is a bit flawed because I think it puts too much responsibility on the view model and not enough on the component. Here's another idea:
- Keep the custom triggering as before. Perhaps change the event name to `"winning-page-show"` or something.
- All components who want to be pages can pass in a `processState` option to the `Presenter` constructor, which takes care of listening for our custom event on the root element and hooking it up to the supplied handler.

Hmm, getting there.
