### PR TITLE
Memoize winControl options. Set options for all elements on process.

### DIFF
--- a/lib/ui/Presenter.js
+++ b/lib/ui/Presenter.js
@@ -15,7 +15,7 @@ function getElementFromTemplate(template) {
     });
 }
 
-function setAllWinControlOptions(rootElement, allWinControlOptions) {
+function setAllWinControlOptionsFor(rootElement, allWinControlOptions) {
     if (!allWinControlOptions) {
         return;
     }
@@ -64,9 +64,22 @@ module.exports = function Presenter(options) {
         });
     }
 
+    function setAllWinControlOptions() {
+        var $elsWithOptions = $(rootElement).find("[data-winning-has-win-control-options]").andSelf();
+
+        $elsWithOptions.each(function (i, element) {
+            var winControlOptions = $(element).data("winning-win-control-options");
+            setAllWinControlOptionsFor(element, winControlOptions);
+        });
+    }
+
     that.render = function () {
-        if (_.has(options, "viewModel")) {
+        if (options.viewModel) {
             ko.applyBindings(options.viewModel, rootElement);
+        }
+        if (options.winControls) {
+            rootElement.setAttribute("data-winning-has-win-control-options", "true");
+            $(rootElement).data("winning-win-control-options", options.winControls);
         }
         if (options.renderables) {
             renderRenderables();
@@ -78,12 +91,12 @@ module.exports = function Presenter(options) {
 
     that.process = function () {
         return Q.when(WinJS.UI.processAll(rootElement)).then(function () {
-            setAllWinControlOptions(rootElement, options.winControls);
+            setAllWinControlOptions();
 
             // Check for renderable elements that need further processing.
-            var processEls = Array.prototype.slice.call(rootElement.querySelectorAll("[data-winning-process]"));
+            var processNodeList = rootElement.querySelectorAll("[data-winning-process]");
 
-            processEls.forEach(function (element) {
+            Array.prototype.forEach.call(processNodeList, function (element) {
                 var onWinControlAvailable = $(element).data("winning-processor");
                 onWinControlAvailable(element, element.winControl);
             });


### PR DESCRIPTION
Each component will memoize their winControl options, which can than later be retrieved when a parent element processes the dom.

This will alway all components to provide winControl optins in the Presenter constructor.
