### PR TITLE
Patch `SemanticZoom._alignViews.

### DIFF
--- a/lib/patches.js
+++ b/lib/patches.js
@@ -60,3 +60,55 @@ exports.patchRenderSelection = function () {
         }
     };
 };
+
+// The `_alignViews` returns a WinJS promise when the current view does not provide a current item.
+// This promise is never resolved as it simply returns an object instead of correctly calling the complete
+// function argument.
+//
+// - Original source at //Microsoft.WinJS.1.0/js/ui.js line 30419
+exports.patchSemanticZoomAlignViews = function () {
+    WinJS.UI.SemanticZoom.prototype._alignViews = function (zoomOut, centerX, centerY, completedCurrentItem) {
+        var multiplier = (1 - this._zoomFactor),
+            rtl = this._rtl(),
+            offsetLeft = multiplier * (rtl ? this._viewportWidth - centerX : centerX),
+            offsetTop = multiplier * centerY;
+
+        var that = this;
+        if (zoomOut) {
+            var item = completedCurrentItem || this._viewIn.getCurrentItem();
+            if (item) {
+                return item.then(function (current) {
+                    var positionIn = current.position,
+                    positionOut = {
+                        left: positionIn.left * that._zoomFactor + offsetLeft,
+                        top: positionIn.top * that._zoomFactor + offsetTop,
+                        width: positionIn.width * that._zoomFactor,
+                        height: positionIn.height * that._zoomFactor
+                    };
+
+                    return that._viewOut.positionItem(that._zoomedOutItem(current.item), positionOut);
+                });
+            }
+        } else {
+            var item2 = completedCurrentItem || this._viewOut.getCurrentItem();
+            if (item2) {
+                return item2.then(function (current) {
+                    var positionOut = current.position,
+                    positionIn = {
+                        left: (positionOut.left - offsetLeft) / that._zoomFactor,
+                        top: (positionOut.top - offsetTop) / that._zoomFactor,
+                        width: positionOut.width / that._zoomFactor,
+                        height: positionOut.height / that._zoomFactor
+                    };
+
+                    return that._viewIn.positionItem(that._zoomedInItem(current.item), positionIn);
+                });
+            }
+        }
+
+        // CHANGE: resovle promise by using complete function argument.
+        return new WinJS.Promise(function (complete) {
+            complete({ x: 0, y: 0 });
+        });
+    };
+};


### PR DESCRIPTION
Correctly resolves the returned promise.
