### PR TITLE
Movin stuff

### DIFF
--- a/lib/ui/Presenter.js
+++ b/lib/ui/Presenter.js
@@ -1,18 +1,9 @@
 "use strict";
 
 var ko = require("knockoutify");
-var domify = require("domify");
 var $ = require("jquery-browserify");
 var Q = require("q");
-var s = require("../resources").s;
-
-function getElementFromTemplate(template) {
-    // Wrap in `MSApp.execUnsafeLocalFunction`, as otherwise it will do crazy stuff like strip out comments (which
-    // breaks Knockout entirely).
-    return MSApp.execUnsafeLocalFunction(function () {
-        return domify(template({ s: s }));
-    });
-}
+var getElementFromTemplate = require("./utils").getElementFromTemplate;
 
 function setAllWinControlOptionsFor(rootElement, allWinControlOptions) {
     if (!allWinControlOptions) {

--- a/lib/ui/renderers.js
+++ b/lib/ui/renderers.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var ko = require("knockoutify");
+var getElementFromTemplate = require("./utils").getElementFromTemplate;
+
+exports.fromComponentFactory = function (componentFactory) {
+    return function (itemPromise) {
+        return itemPromise.then(function (item) {
+            var component = componentFactory(item.data);
+            component.render();
+
+            return component.process();
+        });
+    };
+};
+
+exports.fromTemplate = function (itemTemplate) {
+    return function (itemPromise) {
+        return itemPromise.then(function (item) {
+            var el = getElementFromTemplate(itemTemplate);
+            ko.applyBindings(item.data, el);
+            return el;
+        });
+    };
+};

--- a/lib/ui/utils.js
+++ b/lib/ui/utils.js
@@ -1,5 +1,8 @@
 "use strict";
 
+var domify = require("domify");
+var s = require("../resources").s;
+
 exports.scaleLength = function (length) {
     return Math.round(length * Windows.Graphics.Display.DisplayProperties.resolutionScale / 100);
 };
@@ -22,5 +25,13 @@ exports.createGridLayout = function (cellWidth, cellHeight) {
                 cellHeight: cellHeight
             };
         }
+    });
+};
+
+exports.getElementFromTemplate = function (template) {
+    // Wrap in `MSApp.execUnsafeLocalFunction`, as otherwise it will do crazy stuff like strip out comments (which
+    // breaks Knockout entirely).
+    return MSApp.execUnsafeLocalFunction(function () {
+        return domify(template({ s: s }));
     });
 };

--- a/test/ui_Presenter.coffee
+++ b/test/ui_Presenter.coffee
@@ -19,10 +19,12 @@ Presenter = do ->
         WinJS: WinJS
         MSApp: execUnsafeLocalFunction: (f) -> f()
         Error: Error # necessary for `instanceof Error` checks :-/
+    utilsRequires =
+        "../resources": require("../lib/resources")
+        domify: sandboxedModule.require("domify/lib/domify", { globals })
     requires =
         knockoutify: ko
-        domify: sandboxedModule.require("domify/lib/domify", { globals })
-        "../resources": require("../lib/resources")
+        "./utils": sandboxedModule.require("../lib/ui/utils", { globals, requires: utilsRequires })
         "jquery-browserify": $
 
     sandboxedModule.require("../lib/ui/Presenter", { globals, requires })

--- a/test/ui_renderers.coffee
+++ b/test/ui_renderers.coffee
@@ -1,0 +1,51 @@
+"use strict"
+
+jsdom = require("jsdom").jsdom
+sandboxedModule = require("sandboxed-module")
+Q = require("q")
+
+beforeEach ->
+    @applyBindings = sinon.spy()
+
+    requires =
+        knockoutify:
+            applyBindings: @applyBindings
+        "./utils":
+            getElementFromTemplate: (template) -> template() + " ELEMENTIFIED"
+
+    @renderers = sandboxedModule.require("../lib/ui/renderers", { requires })
+
+describe "Renderer creation", ->
+    specify "fromComponentFactory", ->
+        processResult = { processed: true }
+        processPromise = Q.resolve(processResult)
+        component =
+            render: sinon.spy()
+            process: sinon.stub().returns(processPromise)
+        componentFactory = sinon.stub().returns(component)
+
+        data = { foo: "bar" }
+        itemPromise = Q.resolve({ data })
+
+        renderer = @renderers.fromComponentFactory(componentFactory)
+
+        renderer(itemPromise).then (result) =>
+            result.should.equal(processResult)
+
+            componentFactory.should.have.been.calledWith(data)
+
+            component.render.should.have.been.called
+            component.render.should.have.been.calledBefore(component.process)
+
+    specify "fromTemplate", ->
+        data = { foo: "bar" }
+        itemPromise = Q.resolve({ data })
+
+        template = => "templateResult"
+
+        renderer = @renderers.fromTemplate(template)
+
+        renderer(itemPromise).then (result) =>
+            result.should.equal("templateResult ELEMENTIFIED")
+
+            @applyBindings.should.have.been.calledWith(data, result)


### PR DESCRIPTION
Moved renderers into here from Beretta. Also bugfixed templateRendererFactory (now called `fromTemplate`) to use the common `getElementFromTemplate` function, which uses `MSApp.execUnsafeLocalFunction` and passes the `s` resource string-getter.
