### PR TITLE
Change up the application lifecycle events.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -5,7 +5,7 @@ var patches = require("./patches");
 var app = WinJS.Application;
 var activation = Windows.ApplicationModel.Activation;
 
-var publish = makeEmitter(exports, ["launch", "reactivate", "beforeSuspend"]);
+var publish = makeEmitter(exports, ["launch", "suspend", "resume"]);
 
 exports.start = function () {
     Object.keys(patches).forEach(function (patch) {
@@ -18,8 +18,6 @@ exports.start = function () {
         if (args.detail.kind === activation.ActivationKind.launch) {
             if (args.detail.previousExecutionState !== activation.ApplicationExecutionState.terminated) {
                 publish("launch", args);
-            } else {
-                publish("reactivate", args);
             }
 
             args.setPromise(WinJS.UI.processAll());
@@ -27,7 +25,11 @@ exports.start = function () {
     });
 
     app.addEventListener("checkpoint", function (args) {
-        publish("beforeSuspend", args);
+        publish("suspend", args);
+    });
+
+    Windows.UI.WebUI.WebUIApplication.addEventListener("resuming", function (args) {
+        publish("resume", args);
     });
 
     app.start();


### PR DESCRIPTION
- "beforeSuspend" is renamed to "suspend".
- "reactivate," which we never saw triggered, was replaced with "resume," which is listened to via an entirely-different mechanism.
