### PR TITLE
Fixes the white screen of death problem.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -15,12 +15,13 @@ exports.start = function () {
     WinJS.Binding.optimizeBindingReferences = true;
 
     app.addEventListener("activated", function (args) {
+        // TODO add support for activation kinds other than `launch`
+        // See http://msdn.microsoft.com/en-us/library/windows/apps/windows.applicationmodel.activation.activationkind
         if (args.detail.kind === activation.ActivationKind.launch) {
-            if (args.detail.previousExecutionState !== activation.ApplicationExecutionState.terminated) {
-                publish("launch", args);
-            }
-
+            publish("launch", args);
             args.setPromise(WinJS.UI.processAll());
+        } else {
+            throw new Error("WinningJS - Activated with unknown activation.ActivationKind = " + args.detail.kind);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "WinningJS",
     "description": "A set of modules for Windows 8 development, built on top of WinJS.",
-    "version": "0.0.0-1",
+    "version": "0.0.0-2",
     "author": "NobleJS",
     "contributors": [
         "Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com)",


### PR DESCRIPTION
This occurs when the app starts up after previously being terminated. Also thow an exception if app enters with anything but a `kind` = launch. Lot's more work on supporting other kinds to come.
