### PR TITLE
Process collection change notification handlers on next tick.

### DIFF
--- a/lib/ObservableVectorDataSource.js
+++ b/lib/ObservableVectorDataSource.js
@@ -50,22 +50,26 @@ function ObservableVectorListDataAdapter(observableVector, keySelector, mapping)
         //   `ev.collectionChange` is one of these.
         // - [`IListDataNotificationHandler`](http://msdn.microsoft.com/en-us/library/windows/apps/br212587.aspx):
         //   `that._notificationHandler` is one of these.
-
-        switch (ev.collectionChange) {
-        case Windows.Foundation.Collections.CollectionChange.reset:
-            that._notificationHandler.reload();
-            break;
-        case Windows.Foundation.Collections.CollectionChange.itemInserted:
-            that._notifyInsertedAtIndex(ev.index);
-            break;
-        case Windows.Foundation.Collections.CollectionChange.itemRemoved:
-            // As per internal communication with Microsoft, the key parameter is optional.
-            that._notificationHandler.removed(null, ev.index);
-            break;
-        case Windows.Foundation.Collections.CollectionChange.itemChanged:
-            that._notificationHandler.changed(that._itemFromIndex(ev.index));
-            break;
+        function makeCollectionChangeHandler(collectionChange, index) {
+            return function () {
+                switch (collectionChange) {
+                    case Windows.Foundation.Collections.CollectionChange.reset:
+                        that._notificationHandler.reload();
+                        break;
+                    case Windows.Foundation.Collections.CollectionChange.itemInserted:
+                        that._notifyInsertedAtIndex(index);
+                        break;
+                    case Windows.Foundation.Collections.CollectionChange.itemRemoved:
+                        // As per internal communication with Microsoft, the key parameter is optional.
+                        that._notificationHandler.removed(null, index);
+                        break;
+                    case Windows.Foundation.Collections.CollectionChange.itemChanged:
+                        that._notificationHandler.changed(that._itemFromIndex(index));
+                        break;
+                }
+            };
         }
+        setImmediate(makeCollectionChangeHandler(ev.collectionChange, ev.index));
     });
 }
 


### PR DESCRIPTION
This allows WinJS UI elements to finish rendering themselves when multiple events are triggered.
